### PR TITLE
posts: replace link with archive.org version

### DIFF
--- a/_posts/2017-02-28-a-git-branching-model-for-releases-with-generated-files.md
+++ b/_posts/2017-02-28-a-git-branching-model-for-releases-with-generated-files.md
@@ -194,5 +194,5 @@ Git, e.g. as part of a CI pipeline, is of course good practice!
 Finally, this approach interacts nicely with the [GitWaterFlow] branching model
 we presented at [RELENG'16], but more about that later!
 
-[GitWaterFlow]: http://www.scality.com/blog/continuous-integration-faster-releases-high-quality/
+[GitWaterFlow]: https://web.archive.org/web/20170707112140/http://www.scality.com/blog/continuous-integration-faster-releases-high-quality/
 [RELENG'16]: http://releng.polymtl.ca/RELENG2016/html/index.html


### PR DESCRIPTION
The original website was restructured, and it appears the original
article is gone. Hence, linking to the copy kept by archive.org instead.

See: https://github.com/NicolasT/nicolast.github.io/runs/7103576471?check_suite_focus=true#step:5:20
See: https://nicolast.be/development/a-git-branching-model-for-releases-with-generated-files/
See: https://web.archive.org/web/20170707112140/http://www.scality.com/blog/continuous-integration-faster-releases-high-quality/